### PR TITLE
added test on /transfers endpoint

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -15,7 +15,9 @@
       "args": [
         "-test.v",
         "-test.run",
-        "TestIntegration"
+        "TestIntegration",
+        "-ginkgo.focus",
+        "updates the amount_cents correctly"
       ]
     },
     {

--- a/integration/accounts_test.go
+++ b/integration/accounts_test.go
@@ -3,47 +3,23 @@
 package integration_test
 
 import (
-	"context"
 	"encoding/json"
 	"net/http"
-	"os"
 
-	"github.com/docker/docker/errdefs"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/ossan-dev/bulktransfertests/helpers"
-	tc "github.com/testcontainers/testcontainers-go/modules/compose"
-	"github.com/testcontainers/testcontainers-go/wait"
 	_ "gorm.io/driver/mysql"
 )
 
-var _ = Describe("accounts", Ordered, func() {
-	BeforeAll(func() {
-		os.Setenv("TESTCONTAINERS_RYUK_DISABLED", "true")
-		composeReq, err := tc.NewDockerComposeWith(tc.WithStackFiles("../docker-compose.yml"))
-		Expect(err).Should(BeNil())
-		DeferCleanup(func() {
-			Expect(composeReq.Down(context.Background(), tc.RemoveOrphans(true), tc.RemoveImagesLocal)).Should(BeNil())
-		})
-		ctx, cancel := context.WithCancel(context.Background())
-		DeferCleanup(cancel)
-		var composeErr error
-		composeErr = composeReq.
-			WaitForService("api_service", wait.ForListeningPort("8080/tcp")).
-			Up(ctx, tc.Wait(true))
-		if composeErr != nil && errdefs.IsConflict(composeErr) {
-			composeErr = helpers.ReRunContainersAfterConflict(ctx, composeReq)
-		}
-		Expect(composeErr).Should(BeNil())
-	})
-
+var _ = Describe("accounts endpoint", Ordered, func() {
 	Describe("retrieving accounts", func() {
 		Context("HTTP request is valid", func() {
 			It("return accounts if present in DB", func() {
-				client := http.Client{}
 				r, err := http.NewRequest(http.MethodGet, "http://127.0.0.1:8080/api/accounts?iban=IT10474608000005006107XXXXX", nil)
-				res, err := client.Do(r)
-				Expect(err).Should(BeNil())
+				Expect(err).ShouldNot(HaveOccurred())
+				res, err := httpClient.Do(r)
+				Expect(err).ShouldNot(HaveOccurred())
 				Expect(res).To(HaveHTTPStatus(http.StatusOK))
 				var accounts []helpers.Account
 				Expect(json.NewDecoder(res.Body).Decode(&accounts)).Should(BeNil())
@@ -52,11 +28,10 @@ var _ = Describe("accounts", Ordered, func() {
 				Expect(accounts[0].Iban).To(Equal("IT10474608000005006107XXXXX"))
 			})
 			It("do not return if not present in DB", func() {
-				client := http.Client{}
 				r, err := http.NewRequest(http.MethodGet, "http://127.0.0.1:8080/api/accounts?name=notexistentcompany", nil)
-				Expect(err).Should(BeNil())
-				res, err := client.Do(r)
-				Expect(err).Should(BeNil())
+				Expect(err).ShouldNot(HaveOccurred())
+				res, err := httpClient.Do(r)
+				Expect(err).ShouldNot(HaveOccurred())
 				Expect(res).To(HaveHTTPStatus(http.StatusOK))
 				Expect(res).To(HaveHTTPBody("[]"))
 			})
@@ -64,20 +39,18 @@ var _ = Describe("accounts", Ordered, func() {
 
 		Context("HTTP is not valid", func() {
 			It("err with invalid IBAN", func() {
-				client := http.Client{}
 				r, err := http.NewRequest(http.MethodGet, "http://127.0.0.1:8080/api/accounts?iban=abcd", nil)
-				Expect(err).Should(BeNil())
-				res, err := client.Do(r)
-				Expect(err).Should(BeNil())
+				Expect(err).ShouldNot(HaveOccurred())
+				res, err := httpClient.Do(r)
+				Expect(err).ShouldNot(HaveOccurred())
 				Expect(res).To(HaveHTTPStatus(http.StatusBadRequest))
 			})
 
 			It("err with empty name", func() {
-				client := http.Client{}
 				r, err := http.NewRequest(http.MethodGet, "http://127.0.0.1:8080/api/accounts?name=", nil)
-				Expect(err).Should(BeNil())
-				res, err := client.Do(r)
-				Expect(err).Should(BeNil())
+				Expect(err).ShouldNot(HaveOccurred())
+				res, err := httpClient.Do(r)
+				Expect(err).ShouldNot(HaveOccurred())
 				Expect(res).To(HaveHTTPStatus(http.StatusBadRequest))
 			})
 		})

--- a/integration/integration_suite_test.go
+++ b/integration/integration_suite_test.go
@@ -3,13 +3,57 @@
 package integration_test
 
 import (
+	"context"
+	"database/sql"
+	"net/http"
+	"os"
 	"testing"
 
+	"github.com/docker/docker/errdefs"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"github.com/ossan-dev/bulktransfertests/helpers"
+	tc "github.com/testcontainers/testcontainers-go/modules/compose"
+	"github.com/testcontainers/testcontainers-go/wait"
+)
+
+var (
+	sqlClient  *sql.DB
+	ctx        context.Context
+	cancel     context.CancelFunc
+	httpClient http.Client
 )
 
 func TestIntegration(t *testing.T) {
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "Integration Suite")
 }
+
+var _ = BeforeSuite(func() {
+	os.Setenv("TESTCONTAINERS_RYUK_DISABLED", "true")
+	composeReq, err := tc.NewDockerComposeWith(tc.WithStackFiles("../docker-compose.yml"))
+	Expect(err).ShouldNot(HaveOccurred())
+	DeferCleanup(func() {
+		Expect(composeReq.Down(context.Background(), tc.RemoveOrphans(true), tc.RemoveImagesLocal)).To(Succeed())
+	})
+
+	ctx, cancel = context.WithCancel(context.Background())
+	DeferCleanup(cancel)
+
+	httpClient = http.Client{}
+
+	composeErr := composeReq.
+		WaitForService("api_service", wait.ForListeningPort("8080/tcp")).
+		Up(ctx, tc.Wait(true))
+	if composeErr != nil && errdefs.IsConflict(composeErr) {
+		Expect(helpers.ReRunContainersAfterConflict(ctx, composeReq)).To(Succeed())
+	}
+
+	sqlClient, err = sql.Open("mysql", "root:root@tcp(127.0.0.1:3307)/transfers_db")
+	Expect(err).ShouldNot(HaveOccurred())
+	Expect(sqlClient.Ping()).To(Succeed())
+})
+
+var _ = AfterSuite(func() {
+	Expect(sqlClient.Close()).To(Succeed())
+})

--- a/integration/testdata/single_request.json
+++ b/integration/testdata/single_request.json
@@ -1,0 +1,14 @@
+{
+  "organization_name": "COMPANY 1",
+  "organization_bic": "OIVUSCLQXXX",
+  "organization_iban": "IT10474608000005006107XXXXX",
+  "credit_transfers": [
+    {
+      "amount": "14.5",
+      "counterparty_name": "COUNTERPARTY 1",
+      "counterparty_bic": "CRLYFTTTOU",
+      "counterparty_iban": "EE383680981021245685",
+      "description": "Telephone Company"
+    }
+  ]
+}

--- a/integration/transfers_test.go
+++ b/integration/transfers_test.go
@@ -3,46 +3,62 @@
 package integration_test
 
 import (
-	"context"
-	"database/sql"
-	"os"
+	"bytes"
+	_ "embed"
+	"encoding/json"
+	"net/http"
+	"strconv"
 
-	"github.com/docker/docker/errdefs"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"github.com/ossan-dev/bulktransfertests/helpers"
-	tc "github.com/testcontainers/testcontainers-go/modules/compose"
-	"github.com/testcontainers/testcontainers-go/wait"
 )
 
-// NICE2HAVE: start compose stack only once
-var _ = Describe("transfers", Ordered, func() {
+//go:embed testdata/single_request.json
+var requestBytes []byte
+
+var _ = Describe("transfers endpoint", Ordered, func() {
+	var getAccountBalanceByCompanyName func(companyName string) (balanceCents *int64)
+
 	BeforeAll(func() {
-		os.Setenv("TESTCONTAINERS_RYUK_DISABLED", "true")
-		composeReq, err := tc.NewDockerComposeWith(tc.WithStackFiles("../docker-compose.yml"))
-		Expect(err).Should(BeNil())
-		DeferCleanup(func() {
-			Expect(composeReq.Down(context.Background(), tc.RemoveOrphans(true), tc.RemoveImagesLocal)).Should(BeNil())
-		})
-		ctx, cancel := context.WithCancel(context.Background())
-		DeferCleanup(cancel)
-		var composeErr error
-		composeErr = composeReq.
-			WaitForService("api_service", wait.ForListeningPort("8080/tcp")).
-			Up(ctx, tc.Wait(true))
-		if composeErr != nil && errdefs.IsConflict(composeErr) {
-			composeErr = helpers.ReRunContainersAfterConflict(ctx, composeReq)
+		getAccountBalanceByCompanyName = func(companyName string) (balanceCents *int64) {
+			row := sqlClient.QueryRowContext(ctx, "select balance_cents from bank_accounts ba where organization_name = ?;", companyName)
+			Expect(row.Err()).ShouldNot(HaveOccurred())
+			err := row.Scan(&balanceCents)
+			Expect(err).ShouldNot(HaveOccurred())
+			return
 		}
-		Expect(composeErr).Should(BeNil())
-		sqlClient, err := sql.Open("mysql", "root:root@tcp(127.0.0.1:3307)/transfers_db")
-		Expect(err).Should(BeNil())
-		DeferCleanup(func() {
-			Expect(sqlClient.Close()).Should(BeNil())
-		})
-		Expect(sqlClient.Ping()).Should(BeNil())
 	})
 
-	Describe("test", func() {
-		It("test", func() {})
+	Describe("valid transfers", func() {
+		Context("receive one valid transfer", func() {
+			It("updates the amount_cents correctly", func() {
+				originalBalanceCents := getAccountBalanceByCompanyName("COMPANY 1")
+				Expect(originalBalanceCents).ShouldNot(BeNil())
+				r, err := http.NewRequestWithContext(ctx, http.MethodPost, "http://localhost:8080/api/customer/transfers", bytes.NewReader(requestBytes))
+				r.Header.Set("Content-Type", "application/json")
+				Expect(err).ShouldNot(HaveOccurred())
+				Expect(r).ShouldNot(BeNil())
+				res, err := httpClient.Do(r)
+				Expect(err).ShouldNot(HaveOccurred())
+				defer res.Body.Close()
+
+				var amountField struct {
+					CreditTransfers []struct {
+						Amount string `json:"amount"`
+					} `json:"credit_transfers"`
+				}
+
+				err = json.Unmarshal(requestBytes, &amountField)
+				Expect(err).ShouldNot(HaveOccurred())
+				amount, err := strconv.ParseFloat(amountField.CreditTransfers[0].Amount, 64)
+				Expect(err).ShouldNot(HaveOccurred())
+
+				updatedBalanceCents := getAccountBalanceByCompanyName("COMPANY 1")
+				Expect(updatedBalanceCents).ShouldNot(BeNil())
+
+				Expect(res.StatusCode).Should(BeEquivalentTo(http.StatusCreated))
+				Expect(*originalBalanceCents - int64(amount*100)).Should(BeEquivalentTo(*updatedBalanceCents))
+			})
+		})
 	})
 })


### PR DESCRIPTION
A new integration test has been added. Below, you can find the details:

1. To run it, `cd integration` and execute the command `ginkgo --tags=integration --focus "updates the amount_cents correctly`
2. If you want to debug it, you can add a breakpoint `integration/transfers_test.go:35` and run the VSCode profile `integration-test`. While you're running the test, you can look at the database changes.

It would be nice if you could repro this test in Java. Anyway, make sure to fix the business logic.